### PR TITLE
feat: add timecard entry API and configuration

### DIFF
--- a/famis_client.ts
+++ b/famis_client.ts
@@ -1369,9 +1369,24 @@ export class FamisClient {
     const entity = `users(${userId})/ApproveTimeCard`;
     return this.createObject<LaborEntryApprovalRequest, LaborEntry>(postRequest, entity);
   }
+  //#endregion
 
-  //LaborEntryApprovalRequest
+  //Region Timecard Entries
+  async getTimecardEntries(context: QueryContext): Promise<Result<LaborEntry>> {
+    return this.getAll<LaborEntry>(context, 'timecardentries');
+  }
 
+  async createTimecardEntry(timecardEntry: PostLaborEntryRequest): Promise<LaborEntry> {
+    return this.createObject<PostLaborEntryRequest, LaborEntry>(timecardEntry, 'timecardentries');
+  }
+  
+  async updateTimecardEntry(
+    laborId: string,
+    patchRequest: PostLaborEntryRequest
+  ): Promise<LaborEntry> {
+    return this.patchObject<PostLaborEntryRequest, LaborEntry>(patchRequest, 'timecardentries', laborId);
+  }
+  
   //#endregion
 
   //#region materialcosts

--- a/famis_client.ts
+++ b/famis_client.ts
@@ -105,6 +105,7 @@ import {
   SpaceSubCategory,
   State,
   SubSpace,
+  TimeCardConfiguration,
   TimeZone, TrackingCode,
   Udf,
   UdfField,
@@ -149,6 +150,7 @@ import {
   PostLaborEntryRequest,
   PostMaterialCostRequest,
   PostOtherCostRequest,
+  PostTimecardEntryRequest,
   PostUdfForWoRequest,
   PostWorkOrderRequest,
   PriceAdjustmentTransactionRequest,
@@ -1376,17 +1378,21 @@ export class FamisClient {
     return this.getAll<LaborEntry>(context, 'timecardentries');
   }
 
-  async createTimecardEntry(timecardEntry: PostLaborEntryRequest): Promise<LaborEntry> {
-    return this.createObject<PostLaborEntryRequest, LaborEntry>(timecardEntry, 'timecardentries');
+  async createTimecardEntry(timecardEntry: PostTimecardEntryRequest): Promise<LaborEntry> {
+    return this.createObject<PostTimecardEntryRequest, LaborEntry>(timecardEntry, 'timecardentries');
   }
   
   async updateTimecardEntry(
     laborId: string,
-    patchRequest: PostLaborEntryRequest
+    patchRequest: PostTimecardEntryRequest
   ): Promise<LaborEntry> {
-    return this.patchObject<PostLaborEntryRequest, LaborEntry>(patchRequest, 'timecardentries', laborId);
+    return this.patchObject<PostTimecardEntryRequest, LaborEntry>(patchRequest, 'timecardentries', laborId);
   }
-  
+
+  async getTimecardConfiguration(context: QueryContext): Promise<Result<TimeCardConfiguration>> {
+    return this.getAll<TimeCardConfiguration>(context, 'timecardconfigurations');
+  }
+
   //#endregion
 
   //#region materialcosts

--- a/model/famis_models.ts
+++ b/model/famis_models.ts
@@ -3407,3 +3407,21 @@ export interface TimeZone {
   Default: boolean;
 }
 
+export interface TimeCardConfiguration {
+  Id: number;
+  TeTimecardCostCenterFlag: boolean;
+  TeTimecardAccountsFlag: boolean;
+  TeTimecardWoactivityFlag: boolean;
+  TeTimecardValidateWoFlag: boolean;
+  TeTimecardStartEndTimeFlag: boolean;
+  TeTimecardDtHoursFlag: boolean;
+  TeTimecardRegularHoursLimit: number;
+  TeTimecardOtHoursLimit: number;
+  TeTimecardDtHoursLimit: number;
+  TeManagerSecurityFlag: boolean;
+  TransactionId: number;
+  TeTimecardLrFlag: number;
+  ApprovalNotificationsFlag: boolean;
+  NotifyEmployeeOnNoApprover: boolean | null;
+}
+

--- a/model/request_models.ts
+++ b/model/request_models.ts
@@ -810,6 +810,26 @@ export interface PostLaborEntryRequest {
   LaborReasonId?: number;
 }
 
+export interface PostTimecardEntryRequest {
+  TotalHours?: number;
+  TimeType?: string;
+  ActivityId?: number;
+  ActivityExternalId?: string;
+  Comments?: string;
+  PropertyId?: number;
+  UserId?: number;
+  UserExternalId?: string;
+  EntryDate?: Date;
+  CrewId?: number;
+  CrewExternalId?: string;
+  StartTime?: Date;
+  EndTime?: Date;
+  PositionId?: number;
+  PositionExternalId?: string;
+  LaborReasonId?: number;
+}
+
+
 export interface LaborEntryApprovalRequest {
   LaborEntryIds: number[];
   LaborEntryComment?: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facility360",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A Node based 360Facility client SDK",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Adds client methods and models for timecard entries (list, create, patch) and timecard configuration, plus a `PostTimecardEntryRequest` type aligned with labor entry payloads but scoped to properties instead of requests. Bumps package version to 1.1.2.

## Changes
- `PostTimecardEntryRequest` — same optional fields as `PostLaborEntryRequest` except `RequestId` / `RequestExternalId` removed and `PropertyId` added
- `FamisClient`: `getTimecardEntries`, `createTimecardEntry`, `updateTimecardEntry`, `getTimecardConfiguration`
- `TimeCardConfiguration` model for `timecardconfigurations` API
- Version `1.1.1` → `1.1.2`

## Modified Files

### Core
- `famis_client.ts` — timecard entry CRUD-style helpers and timecard configuration fetch
- `model/request_models.ts` — `PostTimecardEntryRequest`
- `model/famis_models.ts` — `TimeCardConfiguration`
- `package.json` — patch version bump

## Breaking Changes
None

## Testing
- [ ] `npm run build` (TypeScript compile)
- [ ] Manual exercise against FAMIS API (if available)

## Additional Context
Base branch: **master** (per author request).


Made with [Cursor](https://cursor.com)